### PR TITLE
Added @:const property, short for public static inline

### DIFF
--- a/src/tink/lang/sugar/PropertyNotation.hx
+++ b/src/tink/lang/sugar/PropertyNotation.hx
@@ -10,11 +10,13 @@ class PropertyNotation {
 	static public inline var READ = ':read';
 	static public inline var CALC = ':calc';
 	static public inline var LAZY = ':lazy';
+	static public inline var CONST = ':const';
 	
 	static var aliases = [
 		':property' => PROP,
 		':readonly' => READ,
 		':calculated' => CALC,
+		':constant' => CONST,
 	];
 		
 	static public function apply(ctx:ClassBuilder) 
@@ -101,7 +103,23 @@ class PropertyNotation {
 							continue;
 						default: 
 					}
-					
+					switch member.extractMeta(CONST) {
+						case Success(tag):
+							if (e == null)
+								member.pos.error('no expression given');
+							if (t == null)
+								t = e.pos.makeBlankType();
+							member.kind = FProp('get', 'never', t, null);
+							member.isStatic = true;
+							member.isBound = true;
+							member.publish();
+							var getter = Member.getter(name, e, t);
+							getter.isStatic = true;
+							member.isBound = true;
+							add(getter);
+							continue;
+						default: 
+					}
 					switch member.extractMeta(READ) {
 						case Success(tag):
 							switch member.extractMeta(PROP) {


### PR DESCRIPTION
Currently I'm working on a project that uses a lot of event identification constants and business logic contants and I figured that this might be a small improvement:

```
class SomeConstants
{
    public static inline var GRAVITY = 9.81;
    public static inline var EARTH_CIRUM = 40000;
    public static inline var PI = 3.141592;
}
@:tink class SomeConstants
{
    @:const var GRAVITY = 9.81;
    @:const var EARTH_CIRUM = 40000;
    @:const var PI = 3.141592;
}
```

It's currently implemented much like @:calc, but maybe generating the getter method is not needed.
